### PR TITLE
Download 3D packages as extra-data

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,3 @@
 {
-    "only-arches": ["x86_64"],
     "skip-icons-check": true
 }

--- a/org.kicad_pcb.KiCad.Library.Packages3D.json
+++ b/org.kicad_pcb.KiCad.Library.Packages3D.json
@@ -7,24 +7,35 @@
     "build-extension": true,
     "separate-locales": false,
     "appstream-compose": false,
-    "build-options": {
-        "prefix": "/app/library-extensions/Packages3D"
-    },
     "modules": [
         {
             "name": "kicad-packages3D",
+            "buildsystem": "simple",
+            "build-commands": [
+                "install -D apply_extra $FLATPAK_DEST/bin/apply_extra"
+            ],
             "sources": [
                 {
-                    "type": "archive",
+                    "type": "script",
+                    "dest-filename": "apply_extra",
+                    "commands": [
+                        "tar xzf kicad-packages3d.tar.gz --strip-components 1 --wildcards \"*.step\" \"*.wrl\"",
+                        "rm -rf kicad-packages3d.tar.gz"
+                    ]
+                },
+                {
+                    "type": "extra-data",
+                    "filename": "kicad-packages3d.tar.gz",
                     "url": "https://gitlab.com/kicad/libraries/kicad-packages3d/-/archive/5.1.8/kicad-packages3d-5.1.8.tar.gz",
-                    "sha256": "09a0a7417352c07ee1db0ca97c7faf6abff73df238fac7fb0a3db1f2df4cc447"
+                    "sha256": "09a0a7417352c07ee1db0ca97c7faf6abff73df238fac7fb0a3db1f2df4cc447",
+                    "size": 942955426,
+                    "installed-size": 5551588570
                 },
                 {
                     "type": "file",
                     "path": "org.kicad_pcb.KiCad.Library.Packages3D.metainfo.xml"
                 }
             ],
-            "buildsystem": "cmake-ninja",
             "post-install": [
                 "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.kicad_pcb.KiCad.Library.Packages3D.metainfo.xml",
                 "appstream-compose --basename=org.kicad_pcb.KiCad.Library.Packages3D --prefix=${FLATPAK_DEST} --origin=flatpak org.kicad_pcb.KiCad.Library.Packages3D"


### PR DESCRIPTION
KiCAD’s 3D packages have an installed size of about 5.5GB. Including this into the extension itself resulted in frequent build issues on x86_64. Builds on ARM were next-to-impossible (and thus deactivated, leaving users on ARM platforms without an option to download the 3D packages extension).

This PR attempts to resolve the issue by downloading the 3D package data using flatpaks `extra-data` source type, which will download them at installation time. This also allows re-enabling ARM builds of this extension again.

Should be merged shortly after https://github.com/flathub/org.kicad_pcb.KiCad/pull/48