### PR TITLE
Mark the extension end-of-life

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,5 @@
 {
+    "end-of-life": "The extension has been renamed to org.kicad.KiCad.Library.Packages3D",
+    "end-of-life-rebase": "org.kicad.KiCad.Library.Packages3D",
     "skip-icons-check": true
 }


### PR DESCRIPTION
New ID: org.kicad.KiCad.Library.Packages3D
To be merged after https://github.com/flathub/flathub/pull/2041 and https://github.com/flathub/flathub/pull/2042.
@bilelmoussaoui Could you please also archive this repo once this PR has been merged? Thanks.